### PR TITLE
Use production build in container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-FROM node:9.0-alpine
-RUN npm install --global yarn create-react-app
+FROM node:8-alpine as build
 
 WORKDIR /usr/src/app
 COPY package.json /usr/src/app/
 RUN npm install
 COPY . /usr/src/app
+RUN npm run build
 
-CMD [ "npm", "run", "start" ]
+FROM abiosoft/caddy:0.10.10
+
+COPY --from=build /usr/src/app/build /srv
+

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^16.0.0",
     "react-leaflet": "^1.7.1",
     "react-router-dom": "^4.2.2",
-    "react-scripts-ts": "2.7.0"
+    "react-scripts-ts": "2.8.0"
   },
   "scripts": {
     "start": "react-scripts-ts start",
@@ -27,6 +27,9 @@
     "@types/node": "^8.0.34",
     "@types/react": "^16.0.10",
     "@types/react-dom": "^16.0.1",
-    "@types/react-leaflet": "^1.1.4"
+    "@types/react-leaflet": "^1.1.4",
+    "leaflet.awesome-markers": "^2.0.4",
+    "prop-types": "^15.6.0",
+    "typescript": "^2.6.2"
   }
 }


### PR DESCRIPTION
fixes missing dependencies in `package.json`, rewrites `Dockerfile` to utilize multi-stage building, adds `.dockerignore` file which ignores `node_modules` and the `docker` folder.