### PR TITLE
Set some http security headers for all routes

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,3 @@
+/*
+  X-XSS-Protection: 1; mode=block
+  X-Content-Type-Options: nosniff


### PR DESCRIPTION
This pull request sets the http security headers

    X-XSS-Protection: 1; mode=block
    X-Content-Type-Options: nosniff