### PR TITLE
Wenn Nutzer-Koordinaten weit weg sind nehme Stadtmitte als Referenz

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -125,6 +125,7 @@ class App extends React.Component<IAppProps, any> {
 
     if (!navigator.geolocation) {
       console.log('<p>Geolokation wird von ihrem Browser nicht unterstützt</p>');
+      handleMissingCoordinate();
       return;
     }
 


### PR DESCRIPTION
Wenn die lokalisierten Koordinaten des Nutzers mehr als 15 km vom Stadtzentrum entfernt sind wird eh nichts angezeigt und man musste erstmal scrollen. Das wird jetzt so behandelt, als ob die Koordinaten nicht festgestellt werden konnten, sprich die Stadtmitte wird als erster Referenzpunkt genommen.

Relatiert zu #61 