### PR TITLE
Fix icon size in manifest.json

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,7 +4,7 @@
   "icons": [
     {
       "src": "favicon.png",
-      "sizes": "192x192",
+      "sizes": "64x64",
       "type": "image/png"
     }
   ],


### PR DESCRIPTION
This should stop the warning in Chrome devtools

```
Error while trying to use the following icon from the Manifest: https://mein-ms.de/favicon.png (Resource size is not correct - typo in the Manifest?)
```